### PR TITLE
fix: actions correctly repeat now

### DIFF
--- a/luxai_s2/luxai_s2/unit.py
+++ b/luxai_s2/luxai_s2/unit.py
@@ -62,15 +62,14 @@ class Unit:
         action = self.action_queue[0]
         return action
     def repeat_action(self, action):
-        # positive repeat in sequence
-        if action.repeat > 0:
-            action.repeat -= 1
-            return
-        # remove from front of queue
-        self.action_queue.pop(0)
-        # endless repeat puts action back at end of queue
-        if action.repeat == -1:
-            self.action_queue.append(action)
+        action.n -= 1
+        if action.n <= 0:
+            # remove from front of queue
+            self.action_queue.pop(0)
+            # endless repeat puts action back at end of queue
+            if action.repeat:
+                action.n = 1
+                self.action_queue.append(action)
     def move_power_cost(self, rubble_at_target: int):
         return math.floor(self.unit_cfg.MOVE_COST + self.unit_cfg.RUBBLE_MOVEMENT_COST * rubble_at_target)
     def state_dict(self):


### PR DESCRIPTION
The change log of v2.0.0 says, "actions in an action queue can specify both the number of times to repeat it directly, as well as whether to put it back to the end of the action queue once exhausted." However, it is not implemented in `unit.repeat_action`. This commit implements the such feature.