### PR TITLE
Add support for HTML replays

### DIFF
--- a/lux-eye-s2/src/pages/home/HomePage.tsx
+++ b/lux-eye-s2/src/pages/home/HomePage.tsx
@@ -1,10 +1,32 @@
 import { Container, Stack, Text } from '@mantine/core';
+import { Navigate } from 'react-router-dom';
+import { useStore } from '../../store';
+import { notifyError } from '../../utils/notifications';
 import { HomeCard } from './HomeCard';
 import { LoadFromElsewhere } from './LoadFromElsewhere';
 import { LoadFromFile } from './LoadFromFile';
 import { LoadFromKaggle } from './LoadFromKaggle';
 
+declare global {
+  interface Window {
+    episode?: any;
+  }
+}
+
 export function HomePage(): JSX.Element {
+  const episode = useStore(state => state.episode);
+  const load = useStore(state => state.load);
+
+  if (episode === null && window.episode !== undefined) {
+    try {
+      load(window.episode);
+      return <Navigate to="/visualizer" />;
+    } catch (err: any) {
+      console.error(err);
+      notifyError('Cannot load episode', err.message);
+    }
+  }
+
   return (
     <Container>
       <Stack mb="md">

--- a/lux-eye-s2/src/pages/home/LoadFromFile.tsx
+++ b/lux-eye-s2/src/pages/home/LoadFromFile.tsx
@@ -57,9 +57,15 @@ export function LoadFromFile(): JSX.Element {
     <HomeCard title="Load from file">
       {/* prettier-ignore */}
       <Text mb="xs">
-        Supports JSON episodes generated using the <Code>luxai-s2</Code> CLI or the <Code>kaggle-environments</Code> CLI.
+        Supports HTML and JSON episodes generated using the <Code>luxai-s2</Code> CLI and JSON episodes generated using the <Code>kaggle-environments</Code> CLI.
       </Text>
-      <Dropzone onDrop={onDrop} onReject={onReject} multiple={false} accept={['application/json']} loading={loading}>
+      <Dropzone
+        onDrop={onDrop}
+        onReject={onReject}
+        multiple={false}
+        accept={['text/html', 'application/json']}
+        loading={loading}
+      >
         <Dropzone.Idle>
           <DropzoneContent />
         </Dropzone.Idle>

--- a/lux-eye-s2/src/pages/open/OpenPage.tsx
+++ b/lux-eye-s2/src/pages/open/OpenPage.tsx
@@ -7,6 +7,8 @@ import { notifyError } from '../../utils/notifications';
 let hasData = false;
 
 export function OpenPage(): JSX.Element {
+  const load = useStore(state => state.load);
+
   const [seconds, setSeconds] = useState(0);
   const navigate = useNavigate();
 
@@ -19,7 +21,7 @@ export function OpenPage(): JSX.Element {
       hasData = true;
 
       try {
-        useStore.getState().load(event.data);
+        load(event.data);
         navigate('/visualizer');
       } catch (err: any) {
         console.error(err);

--- a/lux-eye-s2/src/store.ts
+++ b/lux-eye-s2/src/store.ts
@@ -83,9 +83,18 @@ export const useStore = create(
 
       load: data => {
         const formatError =
-          'Episode data has unsupported format, only JSON replays generated using the luxai-s2 CLI or the kaggle-environments CLI are supported';
+          'Episode data has unsupported format, only HTML and JSON replays generated using the luxai-s2 CLI and JSON replays generated using the kaggle-environments CLI are supported';
 
         if (typeof data !== 'object') {
+          if (!data.startsWith('{')) {
+            const matches = /window\.episode = (.*);/.exec(data);
+            if (matches === null) {
+              throw new Error(formatError);
+            }
+
+            data = matches[1];
+          }
+
           try {
             data = JSON.parse(data);
           } catch (err) {

--- a/luxai_s2/luxai_runner/cli.py
+++ b/luxai_s2/luxai_runner/cli.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import sys
+from pathlib import Path
 from typing import Dict, List
 
 import numpy as np
@@ -97,9 +98,11 @@ def main():
 
     save_format = getattr(args, "replay.save_format")
     if args.output is not None:
-        output_ext = args.output.split(".")[-1]
-        if output_ext in ["html", "json"]:
-            save_format = output_ext
+        output_file = Path(args.output).name
+        if "." in output_file:
+            output_ext = args.output.split(".")[-1]
+            if output_ext in ["html", "json"]:
+                save_format = output_ext
 
     cfg = EpisodeConfig(
         players=args.players,

--- a/luxai_s2/luxai_runner/cli.py
+++ b/luxai_s2/luxai_runner/cli.py
@@ -35,7 +35,7 @@ def main():
     )
     parser.add_argument(
         "--replay.save_format",
-        help='Save format "json" works with the visualizer while pickle is a compact, python usable version',
+        help='Format of the replay file, can be either "html" or "json". HTML replays are easier to visualize, JSON replays are easier to analyze programmatically. Defaults to the extension of the path passed to --output, or "json" if there is no extension or it is invalid.',
         default="json",
     )
     parser.add_argument(
@@ -95,6 +95,12 @@ def main():
     if sys.platform == "win32":
         asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 
+    save_format = getattr(args, "replay.save_format")
+    if args.output is not None:
+        output_ext = args.output.split(".")[-1]
+        if output_ext in ["html", "json"]:
+            save_format = output_ext
+
     cfg = EpisodeConfig(
         players=args.players,
         env_cls=LuxAI_S2,
@@ -107,7 +113,7 @@ def main():
         verbosity=args.verbose,
         save_replay_path=args.output,
         replay_options=ReplayConfig(
-            save_format=getattr(args, "replay.save_format"),
+            save_format=save_format,
             compressed_obs=getattr(args, "replay.compressed_obs"),
         ),
         render=args.render,


### PR DESCRIPTION
- Added support for `--replay.save_format html` to the CLI. Generated HTML replays show the replay in the visualizer when opened in the browser.
- Changed the default value of `--replay.save_format` to be the extension passed to `--output`, so when running `luxai-s2 --output replay.html` it defaults to HTML format and when running `luxai-s2 --output replay.json` it defaults to JSON format. When there is no extension or it is invalid then JSON format is used.
- Added support for loading HTML replays to the "Load from file" functionality in the visualizer.