### PR TITLE
Fix tournament mode errors for Windows/Java combination

### DIFF
--- a/luxai_s2/luxai_runner/process.py
+++ b/luxai_s2/luxai_runner/process.py
@@ -130,6 +130,9 @@ class BotProcess:
         # return " ".join(stderrs)
 
     async def cleanup(self):
-        self._agent_process._transport.close()
-        self._agent_process.terminate()
-        await self._agent_process.wait()
+        try:
+            self._agent_process._transport.close()
+            self._agent_process.terminate()
+            await self._agent_process.wait()
+        except:
+            pass


### PR DESCRIPTION
If the subprocess is terminated on it's own before the tournament task gets a chance to cleanup itself, the cleanup function errors and causes a premature crash on Windows. Here's an example of what that looks like:

```
Traceback (most recent call last):
  File "/home/amon/.local/bin/luxai-s2", line 8, in <module>
    sys.exit(main())
  File "/home/amon/.local/lib/python3.10/site-packages/luxai_runner/cli.py", line 154, in main
    asyncio.run(tourney.run())
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/home/amon/.local/lib/python3.10/site-packages/luxai_runner/tournament/tournament.py", line 120, in run
    await asyncio.gather(*coros, print_results())
  File "/home/amon/.local/lib/python3.10/site-packages/luxai_runner/tournament/tournament.py", line 78, in _run_episode_cb
    await task
  File "/home/amon/.local/lib/python3.10/site-packages/luxai_runner/tournament/tournament.py", line 124, in _run_episode
    rewards = await eps.run()
  File "/home/amon/.local/lib/python3.10/site-packages/luxai_runner/episode.py", line 187, in run
    await player.proc.cleanup()
  File "/home/amon/.local/lib/python3.10/site-packages/luxai_runner/process.py", line 134, in cleanup
    self._agent_process.terminate()
  File "/usr/lib/python3.10/asyncio/subprocess.py", line 140, in terminate
    self._transport.terminate()
  File "/usr/lib/python3.10/asyncio/base_subprocess.py", line 149, in terminate
    self._check_proc()
  File "/usr/lib/python3.10/asyncio/base_subprocess.py", line 142, in _check_proc
    raise ProcessLookupError()
ProcessLookupError
```

Adding this try/catch block allows it to continue gracefully.