### PR TITLE
Update visualizer for n/repeat changes in 2.1.0

### DIFF
--- a/lux-eye-s2/src/episode/luxai-s2.ts
+++ b/lux-eye-s2/src/episode/luxai-s2.ts
@@ -80,12 +80,14 @@ function parseRobotAction(data: any): RobotAction {
       return {
         type: 'move',
         repeat: data[4],
+        n: data[5],
         direction: data[1],
       };
     case 1:
       return {
         type: 'transfer',
         repeat: data[4],
+        n: data[5],
         direction: data[1],
         resource: data[2],
         amount: data[3],
@@ -94,6 +96,7 @@ function parseRobotAction(data: any): RobotAction {
       return {
         type: 'pickup',
         repeat: data[4],
+        n: data[5],
         resource: data[2],
         amount: data[3],
       };
@@ -101,16 +104,19 @@ function parseRobotAction(data: any): RobotAction {
       return {
         type: 'dig',
         repeat: data[4],
+        n: data[5],
       };
     case 4:
       return {
         type: 'selfDestruct',
         repeat: data[4],
+        n: data[5],
       };
     case 5:
       return {
         type: 'recharge',
         repeat: data[4],
+        n: data[5],
         targetPower: data[3],
       };
     default:

--- a/lux-eye-s2/src/episode/model.ts
+++ b/lux-eye-s2/src/episode/model.ts
@@ -71,6 +71,7 @@ export interface WaterAction extends Action {
 
 export interface RepeatableAction extends Action {
   repeat: number;
+  n?: number;
 }
 
 export interface MoveAction extends RepeatableAction {

--- a/lux-eye-s2/src/pages/visualizer/RobotDetail.tsx
+++ b/lux-eye-s2/src/pages/visualizer/RobotDetail.tsx
@@ -88,7 +88,10 @@ export function RobotDetail({ robot }: RobotDetailProps): JSX.Element {
     let icon: JSX.Element;
     let suffix: string;
 
-    if (action.repeat != 0) {
+    if (action.repeat == 0 && (action.n === undefined || action.n === 1)) {
+      icon = <span>{getActionIcon(action)}</span>;
+      suffix = '';
+    } else if (action.n === undefined) {
       icon = (
         <Indicator inline color="dark" mt={4} size={12} label={action.repeat.toString()}>
           {getActionIcon(action)}
@@ -97,8 +100,13 @@ export function RobotDetail({ robot }: RobotDetailProps): JSX.Element {
 
       suffix = ` (repeat: ${action.repeat})`;
     } else {
-      icon = <span>{getActionIcon(action)}</span>;
-      suffix = '';
+      icon = (
+        <Indicator inline color="dark" mt={4} size={12} label={`${action.n}/${action.repeat}`}>
+          {getActionIcon(action)}
+        </Indicator>
+      );
+
+      suffix = ` (n: ${action.n}, repeat: ${action.repeat})`;
     }
 
     actionQueueIcons.push(


### PR DESCRIPTION
Updated the visualizer so that it renders the label on repeating actions as `n/repeat` rather than only displaying the repeat value for 2.1.0+ episodes.

![](https://user-images.githubusercontent.com/14951909/215904382-dafc876b-581c-4db4-aeea-a97ddcb3f8d1.png)
![](https://user-images.githubusercontent.com/14951909/215904404-4e9caccb-66ef-463e-bce0-46f0d42ae242.png)