### PR TITLE
Support visualizing episodes with null actions

### DIFF
--- a/lux-eye-s2/src/episode/luxai-s2.ts
+++ b/lux-eye-s2/src/episode/luxai-s2.ts
@@ -188,6 +188,7 @@ export function parseLuxAIS2Episode(data: any, teamNames: [string, string] = ['P
     const teams: Team[] = [];
     for (let j = 0; j < 2; j++) {
       const playerId = `player_${j}`;
+      let error: string | null = null;
 
       if (obs.teams[playerId] === undefined) {
         const rawPlayer =
@@ -207,6 +208,8 @@ export function parseLuxAIS2Episode(data: any, teamNames: [string, string] = ['P
           factoriesToPlace: rawPlayer !== null ? rawPlayer.factories_to_place : 0,
 
           action: actions[playerId] !== null ? parseSetupAction(actions[playerId]) : null,
+
+          error,
         });
 
         continue;
@@ -225,6 +228,10 @@ export function parseLuxAIS2Episode(data: any, teamNames: [string, string] = ['P
           }
         }
 
+        if (actions[playerId] === null) {
+          error = 'Actions object is null';
+        }
+
         factories.push({
           unitId,
 
@@ -237,7 +244,10 @@ export function parseLuxAIS2Episode(data: any, teamNames: [string, string] = ['P
           cargo: rawFactory.cargo,
 
           strain: rawFactory.strain_id,
-          action: actions[playerId][unitId] !== undefined ? parseFactoryAction(actions[playerId][unitId]) : null,
+          action:
+            actions[playerId] !== null && actions[playerId][unitId] !== undefined
+              ? parseFactoryAction(actions[playerId][unitId])
+              : null,
 
           lichen,
         });
@@ -246,7 +256,14 @@ export function parseLuxAIS2Episode(data: any, teamNames: [string, string] = ['P
       const robots: Robot[] = [];
       for (const unitId of Object.keys(obs.units[playerId])) {
         const rawRobot = obs.units[playerId][unitId];
-        const actionQueue = actions[playerId][unitId] !== undefined ? actions[playerId][unitId] : rawRobot.action_queue;
+        const actionQueue =
+          actions[playerId] !== null && actions[playerId][unitId] !== undefined
+            ? actions[playerId][unitId]
+            : rawRobot.action_queue;
+
+        if (actions[playerId] === null) {
+          error = 'Actions object is null';
+        }
 
         robots.push({
           unitId,
@@ -279,6 +296,8 @@ export function parseLuxAIS2Episode(data: any, teamNames: [string, string] = ['P
         factoriesToPlace: rawTeam.factories_to_place,
 
         action: isSetupAction(actions[playerId]) ? parseSetupAction(actions[playerId]) : null,
+
+        error,
       });
     }
     steps.push({

--- a/lux-eye-s2/src/episode/model.ts
+++ b/lux-eye-s2/src/episode/model.ts
@@ -152,6 +152,8 @@ export interface Team {
   factoriesToPlace: number;
 
   action: SetupAction | null;
+
+  error: string | null;
 }
 
 export interface Step {

--- a/lux-eye-s2/src/pages/visualizer/TeamCard.tsx
+++ b/lux-eye-s2/src/pages/visualizer/TeamCard.tsx
@@ -15,10 +15,19 @@ export function getWinnerInfo(episode: Episode, team: number): [won: boolean, re
   const me = lastStep.teams[team];
   const opponent = lastStep.teams[team === 0 ? 1 : 0];
 
+  const meError = episode.steps.map(step => step.teams[team].error).some(error => error !== null);
+  const opponentError = episode.steps.map(step => step.teams[team === 0 ? 1 : 0].error).some(error => error !== null);
+
   const meLichen = me.factories.map(factory => factory.lichen).reduce((acc, val) => acc + val, 0);
   const opponentLichen = opponent.factories.map(factory => factory.lichen).reduce((acc, val) => acc + val, 0);
 
-  if (me.faction !== Faction.None && opponent.faction === Faction.None) {
+  if (meError && opponentError) {
+    return [true, 'Draw, both teams errored'];
+  } else if (meError && !opponentError) {
+    return [false, null];
+  } else if (!meError && opponentError) {
+    return [true, 'Winner by opponent error'];
+  } else if (me.faction !== Faction.None && opponent.faction === Faction.None) {
     return [true, 'Winner by opponent error'];
   } else if (me.faction === Faction.None && opponent.faction !== Faction.None) {
     return [false, null];
@@ -136,6 +145,11 @@ export function TeamCard({ id, tabHeight, shadow }: TeamCardProps): JSX.Element 
         <Grid.Col span={1}>
           <b>Heavy robots:</b> {sortedRobots.filter(robot => robot.type === RobotType.Heavy).length}
         </Grid.Col>
+        {team.error && (
+          <Grid.Col span={2}>
+            <b>Error:</b> {team.error}
+          </Grid.Col>
+        )}
 
         {step.step < 0 && (
           <>


### PR DESCRIPTION
This PR makes the visualizer able to visualize episodes where the actions object of a player is `null` for one or more steps. This appears to happen when a team's submission crashes during the episode. At the moment the visualizer shows an error when trying to open these episodes, after this PR it will show "Winner by opponent error" on the winning team and display an error message on the step it happens. An example episode is 46255931:
![](https://user-images.githubusercontent.com/14951909/216444689-9c827db2-8a91-43d1-92f6-4e0d58939108.png)