### PR TITLE
Fix visualizer for lichen strains of destroyed factories

### DIFF
--- a/lux-eye-s2/src/episode/luxai-s2.ts
+++ b/lux-eye-s2/src/episode/luxai-s2.ts
@@ -204,6 +204,8 @@ export function parseLuxAIS2Episode(data: any, teamNames: [string, string] = ['P
           factories: [],
           robots: [],
 
+          strains: new Set(),
+
           placeFirst: rawPlayer !== null ? rawPlayer.place_first : false,
           factoriesToPlace: rawPlayer !== null ? rawPlayer.factories_to_place : 0,
 
@@ -291,6 +293,8 @@ export function parseLuxAIS2Episode(data: any, teamNames: [string, string] = ['P
 
         factories,
         robots,
+
+        strains: new Set(rawTeam.factory_strains),
 
         placeFirst: rawTeam.place_first,
         factoriesToPlace: rawTeam.factories_to_place,

--- a/lux-eye-s2/src/episode/model.ts
+++ b/lux-eye-s2/src/episode/model.ts
@@ -148,6 +148,8 @@ export interface Team {
   factories: Factory[];
   robots: Robot[];
 
+  strains: Set<number>;
+
   placeFirst: boolean;
   factoriesToPlace: number;
 

--- a/lux-eye-s2/src/pages/visualizer/Board.tsx
+++ b/lux-eye-s2/src/pages/visualizer/Board.tsx
@@ -55,8 +55,8 @@ function drawTileBackgrounds(ctx: CanvasRenderingContext2D, config: Config, step
 
   const teamStrains = new Map<number, number>();
   for (let i = 0; i < 2; i++) {
-    for (const factory of step.teams[i].factories) {
-      teamStrains.set(factory.strain, i);
+    for (const strain of step.teams[i].strains) {
+      teamStrains.set(strain, i);
     }
   }
 
@@ -83,11 +83,9 @@ function drawTileBackgrounds(ctx: CanvasRenderingContext2D, config: Config, step
 
       const lichen = board.lichen[tileY][tileX];
       if (lichen > 0) {
-        const team = teamStrains.get(board.strains[tileY][tileX]);
-        if (team !== undefined) {
-          ctx.fillStyle = getTeamColor(team, 0.1 + scale(lichen, 0, 100) * 0.4);
-          ctx.fillRect(canvasX, canvasY, config.tileSize, config.tileSize);
-        }
+        const team = teamStrains.get(board.strains[tileY][tileX])!;
+        ctx.fillStyle = getTeamColor(team, 0.1 + scale(lichen, 0, 100) * 0.4);
+        ctx.fillRect(canvasX, canvasY, config.tileSize, config.tileSize);
       }
     }
   }

--- a/lux-eye-s2/src/pages/visualizer/Chart.tsx
+++ b/lux-eye-s2/src/pages/visualizer/Chart.tsx
@@ -2,11 +2,11 @@ import { Paper } from '@mantine/core';
 import { ApexOptions } from 'apexcharts';
 import { useRef } from 'react';
 import ReactApexChart from 'react-apexcharts';
-import { Team } from '../../episode/model';
+import { Board, Team } from '../../episode/model';
 import { useStore } from '../../store';
 import { getTeamColor } from '../../utils/colors';
 
-export type ChartFunction = (team: Team) => number;
+export type ChartFunction = (team: Team, board: Board) => number;
 
 interface ChartProps {
   title: string;
@@ -74,7 +74,7 @@ export function Chart({ title, func, step }: ChartProps): JSX.Element {
     for (let i = 0; i < steps[0].teams.length; i++) {
       series.push({
         name: steps[0].teams[i].name,
-        data: steps.map(step => func(step.teams[i])),
+        data: steps.map(step => func(step.teams[i], step.board)),
         color: getTeamColor(i, 1.0),
       });
     }

--- a/lux-eye-s2/src/pages/visualizer/TeamCard.tsx
+++ b/lux-eye-s2/src/pages/visualizer/TeamCard.tsx
@@ -8,6 +8,7 @@ import { getTeamColor } from '../../utils/colors';
 import { FactoryDetail } from './FactoryDetail';
 import { RobotDetail } from './RobotDetail';
 import { UnitList } from './UnitList';
+import { funcLichen } from './VisualizerPage';
 
 export function getWinnerInfo(episode: Episode, team: number): [won: boolean, reason: string | null] {
   const lastStep = episode.steps[episode.steps.length - 1];
@@ -18,8 +19,8 @@ export function getWinnerInfo(episode: Episode, team: number): [won: boolean, re
   const meError = episode.steps.map(step => step.teams[team].error).some(error => error !== null);
   const opponentError = episode.steps.map(step => step.teams[team === 0 ? 1 : 0].error).some(error => error !== null);
 
-  const meLichen = me.factories.map(factory => factory.lichen).reduce((acc, val) => acc + val, 0);
-  const opponentLichen = opponent.factories.map(factory => factory.lichen).reduce((acc, val) => acc + val, 0);
+  const meLichen = funcLichen(me, lastStep.board);
+  const opponentLichen = funcLichen(opponent, lastStep.board);
 
   if (meError && opponentError) {
     return [true, 'Draw, both teams errored'];
@@ -134,7 +135,7 @@ export function TeamCard({ id, tabHeight, shadow }: TeamCardProps): JSX.Element 
 
       <Grid columns={2} gutter={0}>
         <Grid.Col span={1}>
-          <b>Lichen:</b> {team.factories.map(factory => factory.lichen).reduce((acc, val) => acc + val, 0)}
+          <b>Lichen:</b> {funcLichen(team, step.board)}
         </Grid.Col>
         <Grid.Col span={1}>
           <b>Light robots:</b> {sortedRobots.filter(robot => robot.type === RobotType.Light).length}

--- a/lux-eye-s2/src/pages/visualizer/VisualizerPage.tsx
+++ b/lux-eye-s2/src/pages/visualizer/VisualizerPage.tsx
@@ -23,7 +23,20 @@ function funcCargo(unitType: 'factories' | 'robots', resource: keyof Cargo): Cha
   return team => (team[unitType] as Unit[]).reduce((acc, val) => acc + val.cargo[resource], 0);
 }
 
-const funcLichen: ChartFunction = team => team.factories.reduce((acc, val) => acc + val.lichen, 0);
+export const funcLichen: ChartFunction = (team, board) => {
+  let lichen = 0;
+
+  const size = board.lichen.length;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      if (board.lichen[y][x] > 0 && team.strains.has(board.strains[y][x])) {
+        lichen += board.lichen[y][x];
+      }
+    }
+  }
+
+  return lichen;
+};
 
 const funcTotalMetalValue: ChartFunction = team =>
   team.factories.reduce((acc, val) => acc + val.cargo.metal, 0) +


### PR DESCRIPTION
Fixes #206. At the moment, on every step the visualizer creates a strain -> team mapping describing what team owns each strain. However, the strains are stored in the factories so when one of them gets destroyed the visualizer incorrectly no longer maps that factory's strain to the team it belonged to. This PR changes that by using the strains stored in `step.teams.player_0/1.factory_strains` instead.