### PR TITLE
Make factory and robot lists scroll to top on hover

### DIFF
--- a/lux-eye-s2/src/pages/visualizer/Board.tsx
+++ b/lux-eye-s2/src/pages/visualizer/Board.tsx
@@ -257,7 +257,7 @@ export function Board({ maxWidth }: BoardProps): JSX.Element {
   const step = episode!.steps[turn];
 
   const onMouseLeave = useCallback(() => {
-    setSelectedTile(null);
+    setSelectedTile(null, true);
   }, []);
 
   useEffect(() => {
@@ -288,7 +288,7 @@ export function Board({ maxWidth }: BoardProps): JSX.Element {
           mouseY >= canvasY &&
           mouseY < canvasY + sizeConfig.tileSize
         ) {
-          setSelectedTile(tile);
+          setSelectedTile(tile, true);
           return;
         }
       }

--- a/lux-eye-s2/src/pages/visualizer/UnitCard.tsx
+++ b/lux-eye-s2/src/pages/visualizer/UnitCard.tsx
@@ -15,8 +15,8 @@ export function UnitCard({ tiles, tileToSelect, children }: UnitCardProps): JSX.
 
   const isSelected = tiles.some(tile => selectedTile?.x === tile.x && selectedTile?.y === tile.y);
 
-  const onMouseEnter = useCallback(() => setSelectedTile(tileToSelect), [tileToSelect]);
-  const onMouseLeave = useCallback(() => setSelectedTile(null), []);
+  const onMouseEnter = useCallback(() => setSelectedTile(tileToSelect, false), [tileToSelect]);
+  const onMouseLeave = useCallback(() => setSelectedTile(null, false), []);
   const style = useMemo(() => ({ background: isSelected ? '#ecf0f1' : 'transparent' }), [isSelected]);
 
   return (

--- a/lux-eye-s2/src/pages/visualizer/UnitList.tsx
+++ b/lux-eye-s2/src/pages/visualizer/UnitList.tsx
@@ -32,7 +32,7 @@ export function UnitList({ name, height, itemCount, tileGetter, itemRenderer }: 
     });
 
     if (itemIndex > -1) {
-      ref.current?.scrollIntoView({ index: itemIndex, behavior: 'smooth' });
+      ref.current?.scrollIntoView({ index: itemIndex, align: 'start', behavior: 'smooth' });
     }
   }, [selectedTile]);
 

--- a/lux-eye-s2/src/pages/visualizer/UnitList.tsx
+++ b/lux-eye-s2/src/pages/visualizer/UnitList.tsx
@@ -14,6 +14,7 @@ interface UnitListProps {
 
 export function UnitList({ name, height, itemCount, tileGetter, itemRenderer }: UnitListProps): JSX.Element {
   const selectedTile = useStore(state => state.selectedTile);
+  const scrollSelectedTileToTop = useStore(state => state.scrollSelectedTileToTop);
 
   const ref = useRef<VirtuosoHandle>(null);
 
@@ -23,7 +24,7 @@ export function UnitList({ name, height, itemCount, tileGetter, itemRenderer }: 
   }
 
   useEffect(() => {
-    if (selectedTile === null) {
+    if (selectedTile === null || !scrollSelectedTileToTop) {
       return;
     }
 

--- a/lux-eye-s2/src/pages/visualizer/UnitList.tsx
+++ b/lux-eye-s2/src/pages/visualizer/UnitList.tsx
@@ -32,7 +32,7 @@ export function UnitList({ name, height, itemCount, tileGetter, itemRenderer }: 
     });
 
     if (itemIndex > -1) {
-      ref.current?.scrollIntoView({ index: itemIndex, align: 'start', behavior: 'smooth' });
+      ref.current?.scrollToIndex({ index: itemIndex, align: 'start', behavior: 'smooth' });
     }
   }, [selectedTile]);
 

--- a/lux-eye-s2/src/store.ts
+++ b/lux-eye-s2/src/store.ts
@@ -13,7 +13,9 @@ export interface State {
 
   turn: number;
   speed: number;
+
   selectedTile: Tile | null;
+  scrollSelectedTileToTop: boolean;
 
   loading: boolean;
   progress: number;
@@ -23,7 +25,7 @@ export interface State {
   setTurn: (turn: number) => void;
   increaseTurn: () => boolean;
   setSpeed: (speed: number) => void;
-  setSelectedTile: (selectedTile: Tile | null) => void;
+  setSelectedTile: (selectedTile: Tile | null, scrollSelectedTileToTop: boolean) => void;
 
   load: (data: any) => void;
   loadFromFile: (file: File) => Promise<void>;
@@ -43,7 +45,9 @@ export const useStore = create(
 
       turn: 1,
       speed: 1,
+
       selectedTile: null,
+      scrollSelectedTileToTop: false,
 
       loading: false,
       progress: 0,
@@ -71,13 +75,15 @@ export const useStore = create(
         }
       },
 
-      setSelectedTile: selectedTile => {
-        const current = get().selectedTile;
+      setSelectedTile: (selectedTile, scrollSelectedTileToTop) => {
+        const { selectedTile: currentSelectedTile, scrollSelectedTileToTop: currentScrollSelectedTileToTop } = get();
         if (
-          (selectedTile === null && current !== null) ||
-          (selectedTile !== null && (selectedTile.x !== current?.x || selectedTile.y !== current?.y))
+          (selectedTile === null && currentSelectedTile !== null) ||
+          (selectedTile !== null &&
+            (selectedTile.x !== currentSelectedTile?.x || selectedTile.y !== currentSelectedTile?.y)) ||
+          scrollSelectedTileToTop !== currentScrollSelectedTileToTop
         ) {
-          set({ selectedTile });
+          set({ selectedTile, scrollSelectedTileToTop });
         }
       },
 


### PR DESCRIPTION
Requested on Discord: https://discord.com/channels/753650408806809672/800945957956485130/1073323591724179619

When you hover over a factory/robot in the visualizer the detail card of that unit is automatically scrolled into view in the factory/robot list of the team it belongs to. The current behavior is to only scroll this list if the card is not already in view, and to scroll it to the top of the list of visible items if it's above the currently visible items and to the bottom if it's below the currently visible items. This PR changes that so that it always scrolls the list to move the detail card to top of the list (if possible), and so that it also scrolls the card to the top if it's already in view but not at the top.