### PR TITLE
RL Kit Environment env.step error

### DIFF
--- a/kits/rl/sb3/train.py
+++ b/kits/rl/sb3/train.py
@@ -56,7 +56,8 @@ class CustomEnvWrapper(gym.Wrapper):
         action = {agent: action}
         obs, _, done, info = self.env.step(action)
         obs = obs[agent]
-        done = done[agent]
+        if not isinstance(done, bool):
+            done = done[agent]
 
         # we collect stats on teams here. These are useful stats that can be used to help generate reward functions
         stats: StatsStateDict = self.env.state.stats[agent]


### PR DESCRIPTION
I encountered an issue with the RL Kit environment's env.step function. Although it seems to work fine on Windows without any changes, increasing the maximum episode steps led to this error. I do not know the cause of this since I am not familiar with stable_baslines and gym. The small change fixed my issue.

Running with 1 env and 1000 max steps
```
Process SpawnProcess-1:
Traceback (most recent call last):
  File "C:\Users\salah\Anaconda3\envs\lux\lib\multiprocessing\process.py", line 297, in _bootstrap
    self.run()
  File "C:\Users\salah\Anaconda3\envs\lux\lib\multiprocessing\process.py", line 99, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\salah\Anaconda3\envs\lux\lib\site-packages\stable_baselines3\common\vec_env\subproc_vec_env.py", line 30, in _worker
    observation, reward, done, info = env.step(data)
  File "C:\Users\salah\Anaconda3\envs\lux\lib\site-packages\stable_baselines3\common\monitor.py", line 94, in step
    observation, reward, done, info = self.env.step(action)
  File "C:\Users\salah\Anaconda3\envs\lux\lib\site-packages\gym\wrappers\time_limit.py", line 18, in step
    observation, reward, done, info = self.env.step(action)
  File "train.py", line 59, in step
    done = done[agent]
TypeError: 'bool' object is not subscriptable
Traceback (most recent call last):
  File "C:\Users\salah\Anaconda3\envs\lux\lib\multiprocessing\connection.py", line 312, in _recv_bytes
    nread, err = ov.GetOverlappedResult(True)
BrokenPipeError: [WinError 109] The pipe has been ended
```